### PR TITLE
bump hot-shots & npm version for dogear v2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "dogear",
 	"description": "A hapi plugin for sending expanded metrics to statsd-compliant services",
-	"version": "2.0.3",
+	"version": "2.0.5",
 	"engines": {
 		"node": ">=4.0.0"
 	},
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/zefferus/dogear#readme",
 	"dependencies": {
-		"hot-shots": "^4.1.1",
+		"hot-shots": "^5.5.1",
 		"hoek": "^4.0.2",
 		"oppsy": "^1.0.2",
 		"lodash.at": "^4.5.0"


### PR DESCRIPTION
 I'm not sure how you'd like to handle the upgrade for the older pre-hapi v17 version of dogear.  I created a v2.x branch which you'd publish separately from your master branch.  I *think* npm is okay with that.