### PR TITLE
call next() when stopping the hapi server to prevent hanging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "dogear",
 	"description": "A hapi plugin for sending expanded metrics to statsd-compliant services",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"engines": {
 		"node": ">=4.0.0"
 	},

--- a/src/dogear.js
+++ b/src/dogear.js
@@ -139,7 +139,8 @@ function attachToServer(server) {
   }
 
 
-  server.ext('onPreStop', () => {
+  server.ext('onPreStop', (server, next) => {
     self.close();
+    next();
   });
 }


### PR DESCRIPTION
v2 wasn't exiting on server.stop, because it wasn't calling `next()`  https://hapijs.com/api/16.6.2#serverextevents

Also bumped the npm version -- **this is just a fix for v2/ pre hapi v17**

It looks like the v17 requires the `onPreStop` to be an async function.  It isn't currently, but we haven't tried stopping dogear under v17 yet.

Please publish v2 to npm if you merge this - thanks!