### PR TITLE
Version bumps all around:

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A hapi plugin for sending request round trip metrics and server ops metrics to a
 This plugin started life as a fork of [hapi-statsd](http://npmjs.com/package/hapi-statsd) and has evolved since then. Thanks to Mac Angell for his hard work on hapi-statsd!
 
 **NOTE:**
+- Dogear 5.x.x works with the namespaced versions of hapi 19 and greater (@hapi/hapi) and requires node v12 or greater.
 - Dogear 4.x.x works with the namespaced versions of hapi 17 and greater (@hapi/hapi).
 - Dogear 3.x.x works with hapi 17 and above.
 - Dogear 2.x.x works with earlier versions.
@@ -16,6 +17,8 @@ This plugin started life as a fork of [hapi-statsd](http://npmjs.com/package/hap
 
 ```bash
 $ npm install --save dogear
+#or
+$ yarn add dogear
 ```
 
 ## Usage
@@ -115,6 +118,7 @@ server.statsd.histogram('timing.metric', 235, [ 'tags' ]);
 
 ## Version Compatibility
 
+- Version 5: @hapi/hapi 19.x.x and higher on Node 12
 - Version 4: @hapi/hapi 17.x.x and higher
 - Version 3: Currently tested with hapi 17.x.x on Node 8
 - Version 2: Up to hapi 16.x.x

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "dogear",
   "description": "A hapi plugin for sending expanded metrics to statsd-compliant services",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "main": "src/index.js",
   "scripts": {
@@ -37,18 +37,18 @@
   },
   "homepage": "https://github.com/zefferus/dogear#readme",
   "dependencies": {
-    "@hapi/hoek": "^6.2.4",
-    "@hapi/oppsy": "^2.1.2",
-    "hot-shots": "^5.0.1",
+    "@hapi/hoek": "^9.0.4",
+    "@hapi/oppsy": "^3.0.0",
+    "hot-shots": "^7.4.2",
     "lodash.at": "^4.6.0"
   },
   "devDependencies": {
-    "@hapi/hapi": "^17.9.0",
-    "babel-eslint": "^8.2.1",
-    "eslint": "^4.17.0",
-    "rimraf": "^2.6.2",
-    "sinon": "^6.3.5",
-    "tap": "^11.1.0"
+    "@hapi/hapi": "^19.1.1",
+    "babel-eslint": "^10.1.0",
+    "eslint": "^6.8.0",
+    "rimraf": "^3.0.2",
+    "sinon": "^9.0.2",
+    "tap": "^14.10.7"
   },
   "peerDependencies": {
     "@hapi/hapi": ">=17"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "tap": "^14.10.7"
   },
   "peerDependencies": {
-    "@hapi/hapi": ">=17"
+    "@hapi/hapi": ">=19"
   }
 }

--- a/test/dogear.test.js
+++ b/test/dogear.test.js
@@ -18,7 +18,7 @@ async function initServer() {
     throw new Error();
   };
 
-  server.route({ method: ['GET', 'OPTIONS'], path: '/', handler: get, config: { cors: true } });
+  server.route({ method: [ 'GET', 'OPTIONS' ], path: '/', handler: get, config: { cors: true } });
   server.route({ method: 'GET', path: '/err', handler: err, config: { cors: true } });
   server.route({ method: 'GET', path: '/test/{param}', handler: get, config: { cors: true } });
 
@@ -28,7 +28,7 @@ async function initServer() {
 
 
 Tap.beforeEach(() => {
-  sandbox = Sinon.sandbox.create();
+  sandbox = Sinon.createSandbox();
 
   return Promise.resolve();
 });


### PR DESCRIPTION
Howdy - I started doing this bring `@hapi/hoek` up to date, and was getting conflicts and version warnings with `@hapi/hapi` unless I brought it up to date as well.  When I did that, I started getting node errors until I moved to the current LTS, v12.

I think with more time you could make a "partial" update without introducing the need for newer node versions (@hapi/hapi v18 should work under node v10).  I figured I would make the most current version possible, get the tests fixed, and make sure the newer requirements were documented in the README and bump this to v5 to follow your previous semver patterns.

- bring @hapi dependencies up to date
- fix tests under newer Sinon api
- update README with changes and new version requirements
- bump version a full number

If it's too much of a jump I understand.  I figured you'd have to make the changes eventually, so why not rip the band-aid off.  =)

If you do merge it, please also publish to npm (I always forget).  Thanks again for your work on this package!